### PR TITLE
Initial role implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+    
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+  # Compensate for repo name being different to the role
+  - ln -s $(pwd) ../stackhpc.dell-powerconnect-switch
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+Dell PowerConnect Switch
+========================
+
+This role configures Dell PowerConnect switches using the `expect` Ansible
+module.
+
+Requirements
+------------
+
+The switches should be configured to allow SSH access.
+
+Role Variables
+--------------
+
+`dell_powerconnect_switch_provider` is authentication provider information,
+similar to the `provider` argument to the `dellos` modules. It should be a dict
+containing the following fields:
+
+- `host`: the host or IP address of the switch.
+- `username`: the username with which to access the switch via SSH.
+- `auth_pass`: the password with which to authenticate.
+
+`dell_powerconnect_switch_config` is a list of configuration lines to apply to
+the switch, and defaults to an empty list.
+
+`dell_powerconnect_switch_interface_config` contains interface configuration.
+It is a dict mapping switch interface names to configuration dicts. Each dict
+may contain the following items:
+
+- `description` - a description to apply to the interface.
+- `config` - a list of per-interface configuration.
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+The following playbook configures hosts in the `dell-powerconnect-switches`
+group.  It assumes host variables for each switch holding the host, username
+and passwords.  It applies global configuration for LLDP, and enables two 10G
+ethernet interfaces as switchports.
+
+    ---
+    - name: Ensure Dell PowerConnect switches are configured
+      hosts: dell-powerconnect-switches
+      gather_facts: no
+      roles:
+        - role: dell-powerconnect-switch
+          dell_powerconnect_switch_provider:
+            host: "{{ switch_host }}"
+            username: "{{ switch_user }}"
+            password: "{{ switch_password }}"
+            transport: cli
+            authorize: yes
+            auth_pass: "{{ switch_auth_pass }}"
+          dell_powerconnect_switch_config:
+            - "protocol lldp"
+            - " advertise dot3-tlv max-frame-size"
+            - " advertise management-tlv management-address system-description system-name"
+            - " advertise interface-port-desc"
+            - " no disable"
+            - " exit"
+          dell_powerconnect_switch_interface_config:
+            Te1/1/1:
+              description: server-1
+              config:
+                - "no shutdown"
+                - "switchport"
+            Te1/1/2:
+              description: server-2
+              config:
+                - "no shutdown"
+                - "switchport"
+
+Author Information
+------------------
+
+- Mark Goddard (<mark@stackhpc.com>)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 Dell PowerConnect Switch
 ========================
 
-This role configures Dell PowerConnect switches using the `expect` Ansible
-module.
+This role configures Dell PowerConnect switches using the
+[expect](http://docs.ansible.com/ansible/latest/modules/expect_module.html?highlight=expect)
+Ansible module.
+
+This role will install the python `expect` package to the system site packages
+on the local machine.
 
 Requirements
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Authentication provider information.
+dell_powerconnect_switch_provider:
+
+# List of configuration lines to apply to the switch.
+dell_powerconnect_switch_config: []
+
+# Interface configuration. Dict mapping switch interface names to configuration
+# dicts. Each dict contains a 'description' item and a 'config' item which
+# should contain a list of per-interface configuration.
+dell_powerconnect_switch_interface_config: {}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Mark Goddard
+  description: >
+    Role to configure Dell PowerConnect switches
+  company: StackHPC Ltd
+  license: Apache2
+  min_ansible_version: 2.0
+  platforms:
+    - name: EL
+      versions:
+        - 7
+  galaxy_tags:
+    - networking
+    - dell
+    - switch
+    - powerconnect

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+# Need to use pip since the CentOS provided package is too old for Ansible.
+- name: Ensure the pexpect Python package is installed
+  local_action:
+    module: pip
+    name: pexpect
+    state: present
+  become: true
+
+- name: Ensure global switch configuration is applied
+  local_action:
+    module: expect
+    command: "ssh {{ dell_powerconnect_switch_provider.username }}@{{ dell_powerconnect_switch_provider.host }}"
+    responses: >-
+      {{ dell_powerconnect_auth_responses |
+         combine(main_responses) |
+         combine(config_responses) }}
+  register: result
+  failed_when: result.get('rc') != 255 or '% Unrecognized command' in result.stdout_lines
+  vars:
+    main_responses: "{{ {dell_powerconnect_main_prompt: ['configure', 'exit']} }}"
+    config_responses: "{{ {dell_powerconnect_config_prompt: dell_powerconnect_switch_config + ['exit']} }}"
+
+- name: Ensure switch interface configuration is applied
+  local_action:
+    module: expect
+    command: ssh {{ dell_powerconnect_switch_provider.username }}@{{ dell_powerconnect_switch_provider.host }}
+    responses: >-
+      {{ dell_powerconnect_auth_responses |
+         combine(main_responses) |
+         combine(config_responses) |
+         combine(interface_responses) }}
+  register: result
+  failed_when: result.get('rc') != 255 or '% Unrecognized command' in result.stdout_lines
+  with_dict: "{{ dell_powerconnect_switch_interface_config }}"
+  vars:
+    main_responses: "{{ {dell_powerconnect_main_prompt: ['configure', 'exit']} }}"
+    config_responses: "{{ {dell_powerconnect_config_prompt: ['interface ' ~ item.key, 'exit']} }}"
+    # Long config lines seem to confuse expect, so we add two exits.
+    interface_responses: >-
+      {{ {dell_powerconnect_interface_prompt:
+          (['description ' ~ item.value.description] if 'description' in item.value else []) +
+          item.value.config | default([]) +
+          ['exit', 'exit']} }}
+  loop_control:
+    label:
+      interface: "{{ item.key }}"
+      description:  "{{ item.value.description | default('<none>') }}"
+      config: "{{ item.value.config | default([]) }}"

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,2 @@
+[switches]
+localhost ansible_connection='local' ansible_python_interpreter='/usr/bin/env python'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: switches
+  connection: local
+  roles:
+    - stackhpc.dell-powerconnect-switch

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,8 @@
+---
+dell_powerconnect_main_prompt: "{{ inventory_hostname }}# "
+dell_powerconnect_config_prompt: "{{ inventory_hostname }}\\(config(-vlan)?\\)# "
+dell_powerconnect_interface_prompt: "{{ inventory_hostname }}\\(config-if\\)# "
+
+dell_powerconnect_auth_responses:
+  "User Name:": "{{ dell_powerconnect_switch_provider.username }}"
+  "Password:": "{{ dell_powerconnect_switch_provider.auth_pass }}"


### PR DESCRIPTION
Some Dell PowerConnect switches do not support the dellos(6|9|10)
Ansible modules, if they are based on an older Dell OS version. This
role uses the Ansible expect module to perform simple switch
configuration.  It has been tested against a Dell PowerConnect 5448.