### PR TITLE
ADD support for vlan 'name' under interface config; ADD more error me…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ It is a dict mapping switch interface names to configuration dicts. Each dict
 may contain the following items:
 
 - `description` - a description to apply to the interface.
+- `name` - a name to apply to the vlan interface, if you're configuring a vlan.
 - `config` - a list of per-interface configuration.
 
 Dependencies
@@ -78,6 +79,10 @@ ethernet interfaces as switchports.
               config:
                 - "no shutdown"
                 - "switchport"
+            "vlan 1234":
+              name: "mytestvlan"
+              config:
+                - "ip address 192.168.1.254 255.255.255.0"
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,6 @@ dell_powerconnect_switch_provider:
 dell_powerconnect_switch_config: []
 
 # Interface configuration. Dict mapping switch interface names to configuration
-# dicts. Each dict contains a 'description' item and a 'config' item which
-# should contain a list of per-interface configuration.
+# dicts. Each dict contains a 'description' (or 'name' in case of vlans) item and 
+# a 'config' item which should contain a list of per-interface configuration.
 dell_powerconnect_switch_interface_config: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,8 @@
     result.get('rc') != 255 or
     '% Unrecognized command' in result.stdout_lines or
     "% Invalid input detected at '^' marker." in result.stdout_lines or
+    "% missing mandatory parameter" in result.stdout_lines or
+    "% bad parameter value" in result.stdout_lines or
     'Connection to ' ~ dell_powerconnect_switch_provider.host ~ ' closed.' not in result.stdout_lines[-1]
   vars:
     enable_responses: "{{ {dell_powerconnect_enable_prompt: ['enable', 'exit']} }}"
@@ -42,6 +44,8 @@
     result.get('rc') != 255 or
     "% Invalid input detected at '^' marker." in result.stdout_lines or
     '% Unrecognized command' in result.stdout_lines or
+    "% missing mandatory parameter" in result.stdout_lines or
+    "% bad parameter value" in result.stdout_lines or
     'Connection to ' ~ dell_powerconnect_switch_provider.host ~ ' closed.' not in result.stdout_lines[-1]
   with_dict: "{{ dell_powerconnect_switch_interface_config }}"
   vars:
@@ -52,10 +56,12 @@
     interface_responses: >-
       {{ {dell_powerconnect_interface_prompt:
           (['description ' ~ item.value.description] if 'description' in item.value else []) +
+          (['name ' ~ item.value.name] if 'name' in item.value else []) +
           item.value.config | default([]) +
           ['exit', 'exit']} }}
   loop_control:
     label:
       interface: "{{ item.key }}"
       description:  "{{ item.value.description | default('<none>') }}"
+      name:  "{{ item.value.name | default('<none>') }}"
       config: "{{ item.value.config | default([]) }}"


### PR DESCRIPTION
* ADD more error messagesssages
* ADD support for vlan 'name' under interface config, which is handy if you want to be able to configure them as interfaces - such as in the case that you need to add an IP address