### PR TITLE
Fix prompt regex for switches without a configured hostname

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,8 @@
 ---
-dell_powerconnect_main_prompt: "{{ inventory_hostname }}#[\\s]?"
-dell_powerconnect_config_prompt: "{{ inventory_hostname }}\\(config(-vlan)?\\)#[\\s]?"
-dell_powerconnect_interface_prompt: "{{ inventory_hostname }}\\(config-if.*\\)#[\\s]?"
-dell_powerconnect_enable_prompt: "{{ inventory_hostname }}>[\\s]?"
+dell_powerconnect_main_prompt: "([Cc]onsole|{{ inventory_hostname }})#[\\s]?"
+dell_powerconnect_config_prompt: "([Cc]onsole|{{ inventory_hostname }})\\(config(-vlan)?\\)#[\\s]?"
+dell_powerconnect_interface_prompt: "([Cc]onsole|{{ inventory_hostname }})\\(config-if.*\\)#[\\s]?"
+dell_powerconnect_enable_prompt: "([Cc]onsole|{{ inventory_hostname }})>[\\s]?"
 
 dell_powerconnect_auth_responses:
   "User Name:": "{{ dell_powerconnect_switch_provider.username }}"


### PR DESCRIPTION
Fixes #4. 

From what I was able to find in Dell's documentation, PowerConnect switches will have a default hostname of either `console` or `Console`. I've tested this fix on a PowerConnect 5524, but as far as I can tell this will work for all other PowerConnect models. 