### PR TITLE
Add write_memory option to save switch configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ may contain the following items:
 - `name` - a name to apply to the vlan interface, if you're configuring a vlan.
 - `config` - a list of per-interface configuration.
 
+`dell_powerconnect_switch_write_memory` is a boolean flag, which when set to true, 
+will save the switch's running configuration to the startup configuration file, 
+after the role applies its configuration. This will allow the configuration to 
+persist after a restart or power failure. By default, this option is set to false. 
+
+`dell_powerconnect_switch_write_command` is the command which is run when the flag 
+dell_powerconnect_switch_write_memory is set to true. The default command is 
+"write memory". 
+
 Dependencies
 ------------
 
@@ -45,8 +54,9 @@ Example Playbook
 
 The following playbook configures hosts in the `dell-powerconnect-switches`
 group.  It assumes host variables for each switch holding the host, username
-and passwords.  It applies global configuration for LLDP, and enables two 10G
-ethernet interfaces as switchports.
+and passwords.  It applies global configuration for LLDP, enables two 10G
+ethernet interfaces as switchports, and saves the configuration changes to
+memory. 
 
     ---
     - name: Ensure Dell PowerConnect switches are configured
@@ -54,6 +64,7 @@ ethernet interfaces as switchports.
       gather_facts: no
       roles:
         - role: dell-powerconnect-switch
+          dell_powerconnect_switch_write_memory: yes
           dell_powerconnect_switch_provider:
             host: "{{ switch_host }}"
             username: "{{ switch_user }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,9 @@ dell_powerconnect_switch_config: []
 # dicts. Each dict contains a 'description' (or 'name' in case of vlans) item and 
 # a 'config' item which should contain a list of per-interface configuration.
 dell_powerconnect_switch_interface_config: {}
+
+# When true, switch configuration will be written to the startup config file.
+write_memory: false
+
+# Change this to override the command to save switch configuration
+write_command: "write memory"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ dell_powerconnect_switch_config: []
 dell_powerconnect_switch_interface_config: {}
 
 # When true, switch configuration will be written to the startup config file.
-write_memory: false
+dell_powerconnect_switch_write_memory: false
 
 # Change this to override the command to save switch configuration
-write_command: "write memory"
+dell_powerconnect_switch_write_command: "write memory"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,3 +65,25 @@
       description:  "{{ item.value.description | default('<none>') }}"
       name:  "{{ item.value.name | default('<none>') }}"
       config: "{{ item.value.config | default([]) }}"
+
+- name: Write running configuration to startup configuration
+  local_action:
+    module: expect
+    command: "ssh {{ ansible_ssh_common_args | default }} {{ dell_powerconnect_switch_provider.username }}@{{ dell_powerconnect_switch_provider.host }}"
+    responses: >-
+      {{ dell_powerconnect_auth_responses |
+         combine(dell_powerconnect_write_responses) |
+         combine(enable_responses) |
+         combine(main_responses) }}
+  register: result
+  failed_when: >-
+    result.get('rc') != 255 or
+    '% Unrecognized command' in result.stdout_lines or
+    "% Invalid input detected at '^' marker." in result.stdout_lines or
+    "% missing mandatory parameter" in result.stdout_lines or
+    "% bad parameter value" in result.stdout_lines or
+    'Connection to ' ~ dell_powerconnect_switch_provider.host ~ ' closed.' not in result.stdout_lines[-1]
+  vars:
+    enable_responses: "{{ {dell_powerconnect_enable_prompt: ['enable', 'exit']} }}"
+    main_responses: "{{ {dell_powerconnect_main_prompt: [write_command, 'exit']} }}"
+  when: write_memory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,5 +85,5 @@
     'Connection to ' ~ dell_powerconnect_switch_provider.host ~ ' closed.' not in result.stdout_lines[-1]
   vars:
     enable_responses: "{{ {dell_powerconnect_enable_prompt: ['enable', 'exit']} }}"
-    main_responses: "{{ {dell_powerconnect_main_prompt: [write_command, 'exit']} }}"
-  when: write_memory
+    main_responses: "{{ {dell_powerconnect_main_prompt: [dell_powerconnect_switch_write_command, 'exit']} }}"
+  when: dell_powerconnect_switch_write_memory | bool

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,6 @@ dell_powerconnect_enable_prompt: "{{ inventory_hostname }}>[\\s]?"
 dell_powerconnect_auth_responses:
   "User Name:": "{{ dell_powerconnect_switch_provider.username }}"
   "(?i).*Password:": "{{ dell_powerconnect_switch_provider.auth_pass }}"
+
+dell_powerconnect_write_responses:
+  "Overwrite file \\[startup\\-config\\] \\?\\[Yes\\/press any key for no\\]\\.\\.\\.\\.": "Y"


### PR DESCRIPTION
This PR adds a `write_memory` config option to the role, which when set to true, will save the running switch configuration to memory (startup configuration) at the end of the role. I have tested this on the PowerConnect 5524, and verified that it works, however more research is needed to see if the yes/no confirmation prompt is different on other models. This is a work in progress; I also still need to add documentation / examples to the Readme. 